### PR TITLE
ActiveJob に関するログ出力先の追加

### DIFF
--- a/lib/lograge_activejob.rb
+++ b/lib/lograge_activejob.rb
@@ -7,6 +7,8 @@ module LogrageActivejob
   mattr_writer :custom_options
   self.custom_options = nil
 
+  mattr_accessor :logger
+
   def custom_options(event)
     if @@custom_options.respond_to?(:call)
       @@custom_options.call(event)
@@ -16,6 +18,7 @@ module LogrageActivejob
   end
 
   def setup(app)
+    LogrageActivejob.logger = app.config.lograge_activejob.logger
     LogrageActivejob.custom_options = app.config.lograge_activejob.custom_options
     LogrageActivejob::LogSubscriber.attach_to :active_job
   end

--- a/lib/lograge_activejob/log_subscriber.rb
+++ b/lib/lograge_activejob/log_subscriber.rb
@@ -11,7 +11,7 @@ module LogrageActivejob
 
     private
       def logger
-        Lograge.logger.presence || super
+        LogrageActivejob.logger.presence || Lograge.logger.presence || super
       end
 
       def initial_data(event)

--- a/lib/lograge_activejob/railtie.rb
+++ b/lib/lograge_activejob/railtie.rb
@@ -1,7 +1,7 @@
 require 'rails/railtie'
 
 module LogrageActivejob
-  Config = Struct.new(:custom_options)
+  Config = Struct.new(:custom_options, :logger)
 
   class Railtie < Rails::Railtie
     config.lograge_activejob = Config.new

--- a/lib/lograge_activejob/version.rb
+++ b/lib/lograge_activejob/version.rb
@@ -1,3 +1,3 @@
 module LogrageActivejob
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/lograge_activejob_log_subscriber_spec.rb
+++ b/spec/lograge_activejob_log_subscriber_spec.rb
@@ -102,4 +102,21 @@ RSpec.describe LogrageActivejob::LogSubscriber do
       expect(log_output.string).to include('data=value')
     end
   end
+
+  context 'when perform an action with lograge_activejob output' do
+    let(:activejob_output) { StringIO.new }
+    let(:activejob_logger) do
+      Logger.new(activejob_output).tap { |logger| logger.formatter = ->(_, _, _, msg) { msg } }
+    end
+
+    before do
+      LogrageActivejob.logger = activejob_logger
+    end
+
+    it 'includes the job_class only in lograge_activejob output' do
+      subscriber.perform(event)
+      expect(log_output.string).not_to include('job_class=TestJob ')
+      expect(activejob_output.string).to include('job_class=TestJob ')
+    end
+  end
 end


### PR DESCRIPTION
lograge_activejob でも出力先を追加できるように修正を行いました。  
もし設定がなければ、lograge で設定したファイルに出力されます。

```ruby
Rails.application.configure do
  config.lograge_activejob.logger = ActiveSupport::Logger.new "#{Rails.root}/log/lograge_activejob_#{Rails.env}.log"
end
```