### PR TITLE
Loosen activesupport/railties version requirement.

### DIFF
--- a/lograge_activejob.gemspec
+++ b/lograge_activejob.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4', '< 5.3'
-  spec.add_runtime_dependency 'railties', '>= 4', '< 5.3'
+  spec.add_runtime_dependency 'activesupport', '>= 4'
+  spec.add_runtime_dependency 'railties', '>= 4'
   spec.add_runtime_dependency 'lograge', '< 1.0'
 
   spec.add_development_dependency 'bundler', '~> 1.16'


### PR DESCRIPTION
This pull removes the version lower then 5.3 requirement for activesupport and railties. Allowing Rails 6.x users (like myself) to use this gem.

An alternative could be to set the values to `'< 7'`.

Let me know what you think :)